### PR TITLE
Fix camera coordinates of NextageKinect

### DIFF
--- a/nextage_tutorials/model/NextageKinect.xacro
+++ b/nextage_tutorials/model/NextageKinect.xacro
@@ -10,11 +10,12 @@
     <child link="WAIST" />
   </joint>
 
-  <!-- copied from   fetch_description/robots/fetch.urdf -->
+  <!-- based on fetch_description/robots/fetch.urdf   -->
+  <!--          nextage_description/urdf/nxo_gz.xacro -->
 
   <link name="head_camera_rgb_frame" />
   <joint name="head_camera_rgb_joint" type="fixed">
-    <origin rpy="0 0 0" xyz="0 0.02 0" />
+    <origin rpy="0 0.25 0" xyz="0.0175 0.02 0.105" />
     <parent link="HEAD_JOINT1_Link" />
     <child link="head_camera_rgb_frame" />
   </joint>
@@ -26,7 +27,7 @@
   </joint>
   <link name="head_camera_depth_frame" />
   <joint name="head_camera_depth_joint" type="fixed">
-    <origin rpy="0 0 0" xyz="0 0.045 0" />
+    <origin rpy="0 0.25 0" xyz="0.0175 0.045 0.105" />
     <parent link="HEAD_JOINT1_Link" />
     <child link="head_camera_depth_frame" />
   </joint>


### PR DESCRIPTION
Previously, camera coordinates of NextageKinect is on neck.
This PR moves camera coordinates to head based on https://github.com/tork-a/rtmros_nextage/blob/0.8.5/nextage_description/urdf/nxo_gz.xacro
| Before this PR | After this PR |
| ---- | ---- |
| ![Screenshot from 2020-05-01 16-09-43](https://user-images.githubusercontent.com/14994939/80790569-31993400-8bca-11ea-8029-6bbef796a71e.png) | ![Screenshot from 2020-05-01 16-32-22](https://user-images.githubusercontent.com/14994939/80790575-352cbb00-8bca-11ea-8592-70b1f89335b4.png) |
